### PR TITLE
Remove lexical-binding from example headers

### DIFF
--- a/front-page.html
+++ b/front-page.html
@@ -87,7 +87,7 @@ M-x customize-variable [RET] package-archives
                         <em>package header</em>:
                     </p>
                     <pre>
-;;; example.el --- example Emacs package -*- lexical-binding: t -*-
+;;; example.el --- example Emacs package
 ;; Copyright (C) 2013 Nic Ferrier
 
 ;; Author: Nic Ferrier <nferrier@example.com>
@@ -111,6 +111,10 @@ M-x customize-variable [RET] package-archives
                    <pre>
 ;;; example.el ends here
                    </pre>
+                   <p>
+                       If you enable `auto-insert-mode`, it will help you insert 
+                       compatible headers in new `.el` files you create.
+                   </p>
                </div>
            </div>
        </div>


### PR DESCRIPTION
People are likely to copy/paste this declaration, possibly inadvertently tying their code to Emacs 24 without declaring a corresponding dependency, so I think it's safer to omit it.

This commit also adds a suggestion to use `auto-insert-mode`.
