### PR TITLE
Properly escape HTML.

### DIFF
--- a/marmalade-tests.el
+++ b/marmalade-tests.el
@@ -611,6 +611,15 @@ test."
            nil)
        (elnode-auth-credentials t)))))
 
+(ert-deftest safe-s-format ()
+  "Test `safe-s-format'."
+  (should (string= (safe-s-format "foo ${bar} baz" 'aget '(("bar" . "<i> &")))
+                   "foo &lt;i&gt; &amp; baz"))
+  (should (string= (safe-s-format "foo $1 baz" 'elt '("bar" "a<i"))
+                   "foo a&lt;i baz"))
+  (should (string= (safe-s-format "${x} xxx" #'(lambda (&rest x) "&a>i"))
+                   "&amp;a&gt;i xxx")))
+
 (provide 'marmalade-tests)
 
 ;;; marmalade-tests.el ends here


### PR DESCRIPTION
Not escaping HTML could result in an XSS vulnerability.
- marmalade-service.el (safe-s-format): New function.
  (marmalade/package-blurb): User `safe-s-format',`xml-escape-string'
  in error case, and minor HTML fixes/changes.
- marmalade-tests.el (safe-s-format): New test.

Note: I couldn't fully test the resulting HTML because I don't have a locale elmarmalade test setup.  This is more an "inspiration" to fix the issue.
