### PR TITLE
Minor Fixes

### DIFF
--- a/marmalade-service.el
+++ b/marmalade-service.el
@@ -196,7 +196,7 @@ If the target package already exists a `file-error' is produced."
           (marmalade/temp-file package-file-name)))
     ;; First save the uploaded data to a temp package file
     (with-temp-file temp-package-file
-      (insert-string (substring-no-properties package-data)))
+      (insert (substring-no-properties package-data)))
     ;; Return the package info, the package-path and the temp file
     (append
      (marmalade/package-path temp-package-file)
@@ -494,7 +494,7 @@ M-x package-install [RET] ${package-name} [RET]
      `(("username" . ,username)))))
 
 (defconst marmalade/page-file
-  (concat marmalade-dir "front-page.html"))
+  (expand-file-name "front-page.html" marmalade-dir))
 
 (defun marmalade/latest-html ()
   (let* ((latest (marmalade/package-list :sorted 5 :take 10)))
@@ -525,11 +525,11 @@ M-x package-install [RET] ${package-name} [RET]
   (with-elnode-auth httpcon 'marmalade-auth
     (elnode-send-file
      httpcon
-     (concat marmalade-dir "upload-page.html"))))
+     (expand-file-name "upload-page.html" marmalade-dir))))
 
-(defun marmalade/login-sender (httpcon target redirect)
+(defun marmalade/login-sender (httpcon _target _redirect)
   "Send the login page."
-  (let ((page-file (concat marmalade-dir "login-page.html")))
+  (let ((page-file (expand-file-name "login-page.html" marmalade-dir)))
     (elnode-send-file httpcon page-file)))
 
 (defun marmalade/auth-test (username)
@@ -552,7 +552,7 @@ M-x package-install [RET] ${package-name} [RET]
 
 (defconst marmalade/webserver
   (elnode-webserver-handler-maker
-   (concat marmalade-dir "static"))
+   (expand-file-name "static" marmalade-dir))
   "The webserver for marmalade.")
 
 (defun marmalade/special-docs (httpcon)
@@ -560,7 +560,7 @@ M-x package-install [RET] ${package-name} [RET]
   (let ((matched (elnode-http-mapping httpcon 1)))
     (elnode-send-file
      httpcon
-     (concat marmalade-dir "/" matched ".html"))))
+     (expand-file-name (concat matched ".html") marmalade-dir))))
 
 (defun marmalade-router (httpcon)
   "The top level router for marmalade-repo."


### PR DESCRIPTION
Some minor fixes (untested):
- Set error status when an internal error happens.
- Use `expand-file-name` instead of `concat`
- Replace `insert-string` with `insert`
