### PR TITLE
Move profile pages to the original URL

### DIFF
--- a/marmalade-service.el
+++ b/marmalade-service.el
@@ -523,7 +523,7 @@ is grabbed."
          ("^[^/]+//v1/users/login/*$" .  marmalade-api/user-login)
 
          ;; The profile
-         ("^[^/]+//profile/\\([^/]+\\)/*" . marmalade-user-profile)
+         ("^[^/]+//profiles/\\([^/]+\\)/*" . marmalade-user-profile)
 
          ("^[^/]+//$" . marmalade/packages-index))
        :log-name "marmalade"

--- a/marmalade-vars.el
+++ b/marmalade-vars.el
@@ -24,7 +24,7 @@
             <div class=\"navbar-inner\">
                 <ul class=\"nav pull-right\">
                     <li class=\"active\"><a href=\"/\">marmalade-repo</a></li>
-                    <li><a href=\"/profile/${username}/\">${username}</a></li>
+                    <li><a href=\"/profiles/${username}/\">${username}</a></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
The URL of the profile pages used to be /profiles/<user-name>.

I propose changing it back to that to not break existing links.

(the profile pages don't work currently - but that is probably better to be handled in another issue)
