### PR TITLE
Fix link to Github repo

### DIFF
--- a/specialpages/register-comingsoon.html
+++ b/specialpages/register-comingsoon.html
@@ -21,7 +21,7 @@
     <h1>sorry... you can't register for marmalade-repo ...</h1>
     <h3>We just haven't got a working registration yet. But it's coming very soon.<h3>
     <h4>In the mean time, if you need an account, please add an issue on the 
-    <a href="http://github/nicferrier/elmarmalade">github</a>.</h4>
+    <a href="https://github.com/nicferrier/elmarmalade">github</a>.</h4>
 </div>
 </div>
 </div>


### PR DESCRIPTION
The Github repo link was missing a `.com`.
